### PR TITLE
Removed `seth init` line from RPC service command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,10 +124,12 @@ services:
     container_name: seth-rpc
     depends_on:
       - validator
+    expose:
+      - 3030 
     ports:
-      - 3030:3030
+      - '3030:3030'
     command: |
       bash -c "
-        seth init http://rest-api:8080 &&
         seth-rpc --connect tcp://validator:4004 --bind 0.0.0.0:3030
       "
+


### PR DESCRIPTION
After adding proxy to build.args in docker-compose-installed. The RPC does not start up properly in the docker-compose file with proxy build.args. BWO of asking and testing the `seth init` line can be removed from the RPC service command. So the RPC does not try to startup improperly. 

To check the RPC endpoint is working, on a new Terminal ran the following curl to test and receives the current block number. This confirms that the guest machine is able to talk to the dockerized Seth RPC Endpoint.

$ curl http://0.0.0.0:3030 -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_blockNumber"}' -H "Content-Type: application/json"